### PR TITLE
Move tape to dev-dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "url": "https://github.com/miguelmota/is-class/issues"
   },
   "homepage": "https://github.com/miguelmota/is-class",
-  "dependencies": {
+  "dependencies": {},
+  "devDependencies": {
     "tape": "^3.0.3"
   }
 }


### PR DESCRIPTION
Moved tape to a `devDependency` as it is only necessary for development.
More info here: https://docs.npmjs.com/files/package.json#devdependencies
