### PR TITLE
Fixed check for inlined babel class call check

### DIFF
--- a/is-class.js
+++ b/is-class.js
@@ -6,10 +6,17 @@
   }
 
   function isClass(fn) {
-    return (typeof fn === 'function' &&
-            (/^class[\s{]/.test(toString.call(fn)) ||
-              (/classCallCheck\(/.test(fnBody(fn)))) // babel.js
-            );
+    if (typeof fn !== 'function') {
+      return false;
+    }
+
+    if (/^class[\s{]/.test(toString.call(fn))) {
+      return true;
+    }
+
+    // babel.js classCallCheck() & inlined
+    const body = fnBody(fn);
+    return (/classCallCheck\(/.test(body) || /TypeError\("Cannot call a class as a function"\)/.test(body));
   }
 
   if (typeof exports !== 'undefined') {


### PR DESCRIPTION
Sometimes the babel classCallCheck method was inlined in my transpiled code, that way the current detection was failing. I've added a check for the  inlined TypeError that is thrown, so detection works as expected. 